### PR TITLE
fix Maven repo mapping configuration in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ you have a Maven settings.xml that defines the following credentials:
     </settings>
 
 As you can see, we have credentials associated with a repository server with the identifier of
-"jboss-developer-repository-group".  This is the information we need supply in order for the plugin to make the
+"dogdeball-repo".  This is the information we need supply in order for the plugin to make the
 connection.  In the Publication DSL, this corelates to the `name` attribute of the repository configuration:
 
     publishing {
         repositories {
             maven {
-                ext.id = 'dogdeball-repo'
+                name = 'dogdeball-repo'
                 url 'http://repository.average.joes.com'
             }
         }


### PR DESCRIPTION
Looks like it wasn't updated after changes done in 2.0.0. I took me a while to noticed why it doesn't work in my project :-).
