### PR TITLE
Only adds credentials to those supported transport protocols that accept user:pass

### DIFF
--- a/src/main/java/org/hibernate/build/publish/auth/maven/DependencyRepoHandler.java
+++ b/src/main/java/org/hibernate/build/publish/auth/maven/DependencyRepoHandler.java
@@ -23,8 +23,7 @@ public class DependencyRepoHandler {
 		project.afterEvaluate(
 				p -> p.getRepositories().withType( MavenArtifactRepository.class ).all(
 						repo -> Helper.applyCredentials(
-								repo.getName(),
-								repo.getCredentials(),
+								repo,
 								credentialsProviderRegistry
 						)
 				)

--- a/src/main/java/org/hibernate/build/publish/auth/maven/LegacyHandler.java
+++ b/src/main/java/org/hibernate/build/publish/auth/maven/LegacyHandler.java
@@ -7,8 +7,6 @@
 package org.hibernate.build.publish.auth.maven;
 
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.maven.MavenDeployer;
-import org.gradle.api.artifacts.maven.MavenResolver;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.tasks.Upload;
@@ -37,8 +35,7 @@ public class LegacyHandler {
 			if ( repository instanceof MavenArtifactRepository ) {
 				final MavenArtifactRepository mavenRepo = (MavenArtifactRepository) repository;
 				Helper.applyCredentials(
-						mavenRepo.getName(),
-						mavenRepo.getCredentials(),
+						mavenRepo,
 						credentialsProviderRegistry
 				);
 			}

--- a/src/main/java/org/hibernate/build/publish/auth/maven/PublishingRepoHandler.java
+++ b/src/main/java/org/hibernate/build/publish/auth/maven/PublishingRepoHandler.java
@@ -28,8 +28,7 @@ public class PublishingRepoHandler {
 								final MavenArtifactRepository mavenRepo = (MavenArtifactRepository) repo;
 
 								Helper.applyCredentials(
-										mavenRepo.getName(),
-										mavenRepo.getCredentials(),
+										mavenRepo,
 										credentialsProviderRegistry
 								);
 							}


### PR DESCRIPTION
There are only a handful of supported transport protocols for Maven in Gradle and only a subset of those use `username:password` credentials.

Limit the repositories that have credentials added to those that work.

Check the [Gradle docs here](https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:supported_transport_protocols) for more details.


Fixes: #24 